### PR TITLE
Wiring function tools + MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,35 @@ This module demonstrates a multi‑agent system orchestrated by an Akka Java SDK
 
 ## Run
 - Prereq: set `OPENAI_API_KEY`.
-- Optional: set `MCP_HTTP_URL` (default `http://localhost:7400/jsonrpc`) to enable MCP tool calls.
+- Optional: set `MCP_HTTP_URL` (default `http://localhost:9100/mcp`) to enable MCP tool calls.
 - Build: `mvn -f spov-sample-agentic-workflow/pom.xml clean package`
 - Dev mode: starts on `:9100` (configured in `src/main/resources/application.conf`).
 
 ## HTTP
 - Start triage: `POST /triage/{triageId}` with body `{ "incident": "<summary>" }`
 - Get conversation: `GET /triage/{triageId}`
-- MCP mock server: `POST /mcp` accepts JSON‑RPC `{ "jsonrpc":"2.0", "id": "...", "method":"call_tool", "params": {"name":"...","arguments": {..}} }` and returns a mocked result.
+- MCP server: `POST /mcp` accepts JSON‑RPC `{ "jsonrpc":"2.0", "id": "...", "method":"call_tool", "params": {"name":"...","arguments": {..}} }` and serves file‑based logs/metrics. Replace with real backends as needed.
+
+## MCP Configuration
+
+- Endpoint resolution order for agents (EvidenceAgent via `McpClient`, TriageAgent via `mcp-call`):
+  1) System property `MCP_HTTP_URL`
+  2) Environment variable `MCP_HTTP_URL`
+  3) `mcp.http.url` in `application.conf`
+  4) Default `http://localhost:9100/mcp`
+
+- Default config in `src/main/resources/application.conf`:
+
+```
+mcp.http.url = "http://localhost:9100/mcp"
+akka.javasdk.dev-mode.http-port = 9100
+```
+
+- Override example:
+
+```
+MCP_HTTP_URL=https://mcp.internal/jsonrpc mvn -f spov-sample-agentic-workflow/pom.xml exec:java
+```
 
 ## UI
 - Open `GET /` to use the minimal web UI to start a triage and inspect conversations/state.

--- a/docs/mcp.http
+++ b/docs/mcp.http
@@ -1,0 +1,140 @@
+@baseUrl = http://localhost:9100
+@json = application/json
+
+# About this file
+# - These JSON-RPC calls hit the in-app MCP endpoint (`POST {{baseUrl}}/mcp`).
+# - The MCP server here is a reference that reads from classpath files.
+# - In a real setup, this MCP endpoint should WRAP your observability backends.
+#
+# Typical backends to wrap:
+# - Logs: Grafana Loki, Elasticsearch (ELK/OpenSearch), Splunk, CloudWatch Logs, GCP Cloud Logging.
+# - Metrics: Prometheus/Thanos/VictoriaMetrics, Datadog, New Relic, CloudWatch Metrics, GCP Cloud Monitoring.
+#
+# Mapping ideas:
+# - fetch_logs(service, lines, range):
+#   - Loki: `{app="{{service}}"}` + tail over `range`, limit = `lines`.
+#   - Elasticsearch: index pattern per service, `query_string` with time filter (range → @timestamp).
+#   - Splunk: `search index=prod service={{service}} earliest=-{{range}} | head {{lines}}`
+#   - CloudWatch Logs: Log group `/aws/ecs/{{service}}`; FilterLogEvents with `startTime`/`endTime` and `limit=lines`.
+# - query_metrics(expr, range):
+#   - Prometheus: PromQL, e.g. `rate(http_requests_total{service="checkout",code=~"5.."}[5m])` over `range`.
+#   - Datadog: timeseries, e.g. `avg:errors.rate{service:checkout}.rollup(60)`; map `range` to from/to.
+#   - CloudWatch Metrics: Map `expr` to (Namespace, MetricName, Dimensions), use `GetMetricData` over `range`.
+#   - New Relic/GCP: Map `expr` to NRQL/Monitoring filters respectively.
+
+### fetch_logs: payment-service, 100 lines, 1h
+# Example real-world mapping:
+# - Loki: `{app="payment-service"}` over last 1h, limit 100
+# - Elasticsearch: index=logs-*, query="service:payment-service AND @timestamp:[now-1h TO now]" size=100 sort=desc
+POST {{baseUrl}}/mcp
+Content-Type: {{json}}
+
+{
+  "jsonrpc": "2.0",
+  "id": "logs-1",
+  "method": "call_tool",
+  "params": {
+    "name": "fetch_logs",
+    "arguments": {
+      "service": "payment-service",
+      "lines": 100,
+      "range": "1h"
+    }
+  }
+}
+
+### fetch_logs: checkout-service, 50 lines, 30m
+# Example real-world mapping:
+# - Splunk: `search index=prod service=checkout earliest=-30m | head 50`
+# - CloudWatch Logs: group=/aws/ecs/checkout, limit=50, startTime=now-30m
+POST {{baseUrl}}/mcp
+Content-Type: {{json}}
+
+{
+  "jsonrpc": "2.0",
+  "id": "logs-2",
+  "method": "call_tool",
+  "params": {
+    "name": "fetch_logs",
+    "arguments": {
+      "service": "checkout-service",
+      "lines": 50,
+      "range": "30m"
+    }
+  }
+}
+
+### fetch_logs: using stringified arguments (supported)
+# Stringified `arguments` are accepted by the endpoint as well
+POST {{baseUrl}}/mcp
+Content-Type: {{json}}
+
+{
+  "jsonrpc": "2.0",
+  "id": "logs-3",
+  "method": "call_tool",
+  "params": {
+    "name": "fetch_logs",
+    "arguments": "{\"service\":\"user-service\",\"lines\":50,\"range\":\"30m\"}"
+  }
+}
+
+### query_metrics: errors:rate5m over 1h
+# Example real-world mapping:
+# - Prometheus: `rate(http_requests_total{service="payment-service",code=~"5.."}[5m])`
+# - Datadog: `avg:service.errors{service:payment-service}.rollup(60)`
+POST {{baseUrl}}/mcp
+Content-Type: {{json}}
+
+{
+  "jsonrpc": "2.0",
+  "id": "metrics-1",
+  "method": "call_tool",
+  "params": {
+    "name": "query_metrics",
+    "arguments": {
+      "expr": "errors:rate5m",
+      "range": "1h"
+    }
+  }
+}
+
+### query_metrics: latency p99 over 1h
+# Example real-world mapping:
+# - Prometheus: `histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{service="api"}[5m])) by (le))`
+# - CloudWatch Metrics: MetricName=TargetResponseTime (ALB), Dimension=TargetGroup, Statistic=p99
+POST {{baseUrl}}/mcp
+Content-Type: {{json}}
+
+{
+  "jsonrpc": "2.0",
+  "id": "metrics-2",
+  "method": "call_tool",
+  "params": {
+    "name": "query_metrics",
+    "arguments": {
+      "expr": "latency:p99",
+      "range": "1h"
+    }
+  }
+}
+
+### query_metrics: cpu utilization over 2h
+# Example real-world mapping:
+# - Prometheus: `avg(rate(container_cpu_usage_seconds_total{service="user-service"}[5m])) by (service)`
+# - CloudWatch Metrics: Namespace=ECS/ContainerInsights, MetricName=CpuUtilized, Dimensions=Cluster/Service
+POST {{baseUrl}}/mcp
+Content-Type: {{json}}
+
+{
+  "jsonrpc": "2.0",
+  "id": "metrics-3",
+  "method": "call_tool",
+  "params": {
+    "name": "query_metrics",
+    "arguments": {
+      "expr": "cpu:utilization",
+      "range": "2h"
+    }
+  }
+}

--- a/docs/triage.http
+++ b/docs/triage.http
@@ -1,0 +1,30 @@
+@baseUrl = http://localhost:9100
+@json = application/json
+@triageId = TRIAGE-20251013T014730-08k1
+
+### Start triage workflow
+POST {{baseUrl}}/triage/{{triageId}}
+Content-Type: {{json}}
+
+{
+  "incident": "Checkout 5xx spike after deployment v2.1.4 at 14:25 UTC. Users report failures; error rate above 10%."
+}
+
+### Get conversations for the workflow
+GET {{baseUrl}}/triage/{{triageId}}
+
+### Get current workflow state
+GET {{baseUrl}}/triage/{{triageId}}/state
+
+### Repeat a message in workflow (debug/demo helper)
+POST {{baseUrl}}/triage/{{triageId}}/repeat
+Content-Type: {{json}}
+
+{
+  "message": "Hello",
+  "times": 2
+}
+
+### Open simple UI (if browsing via REST Client preview)
+GET {{baseUrl}}/
+

--- a/src/main/java/com/example/sample/application/RemediationAgent.java
+++ b/src/main/java/com/example/sample/application/RemediationAgent.java
@@ -46,7 +46,7 @@ public class RemediationAgent extends Agent {
            - Plan automated and manual validation procedures
            - Design alerting for remediation failures
         
-        **IMPORTANT**: Before formulating a plan, you MUST use the `search_knowledge_base` tool to find existing runbooks or incident reports related to the service and symptoms. This is critical for creating a safe and effective plan.
+        **IMPORTANT**: Before formulating a plan, review the provided 'KNOWLEDGE BASE SEARCH RESULTS'. If this section is missing or insufficient, explicitly note the knowledge gaps and what information is needed from the knowledge base so the workflow can fetch it. This is critical for creating a safe and effective plan.
 
         Use other available tools to validate assumptions and gather additional context.
         

--- a/src/main/java/com/example/sample/application/TriageAgent.java
+++ b/src/main/java/com/example/sample/application/TriageAgent.java
@@ -144,8 +144,16 @@ public class TriageAgent extends Agent {
             @Description("Tool name to invoke on the MCP server") String toolName,
             @Description("JSON string of arguments for the tool call") String argumentsJson
     ) {
-        String endpoint = System.getProperty("MCP_HTTP_URL",
-                System.getenv().getOrDefault("MCP_HTTP_URL", "http://localhost:7400/jsonrpc"));
+        String endpoint;
+        try {
+            var cfg = com.typesafe.config.ConfigFactory.load();
+            endpoint = System.getProperty("MCP_HTTP_URL",
+                    System.getenv().getOrDefault("MCP_HTTP_URL",
+                            cfg.hasPath("mcp.http.url") ? cfg.getString("mcp.http.url") : "http://localhost:9100/mcp"));
+        } catch (Throwable t) {
+            endpoint = System.getProperty("MCP_HTTP_URL",
+                    System.getenv().getOrDefault("MCP_HTTP_URL", "http://localhost:9100/mcp"));
+        }
         String id = java.util.UUID.randomUUID().toString();
 
         // Basic escape for tool name to embed in JSON

--- a/src/main/java/com/example/sample/application/TriageWorkflow.java
+++ b/src/main/java/com/example/sample/application/TriageWorkflow.java
@@ -10,7 +10,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import com.example.sample.domain.TriageState;

--- a/src/main/java/com/example/sample/mock/McpMockEndpoint.java
+++ b/src/main/java/com/example/sample/mock/McpMockEndpoint.java
@@ -6,42 +6,131 @@ import akka.javasdk.annotations.http.HttpEndpoint;
 import akka.javasdk.annotations.http.Post;
 import akka.javasdk.http.HttpResponses;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
 @Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET))
 @HttpEndpoint("/mcp")
 public class McpMockEndpoint {
 
-    @Post
-    public HttpResponse call(String body) {
-        // Minimal echo JSON-RPC response: extract id if present and wrap a fake result
-        String id = extractJsonId(body);
-        String result = "{\"output\":\"mocked tool output\"}";
-        String response = "{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"result\":" + result + "}";
-        return HttpResponses.ok(response);
-    }
+    private static final ObjectMapper mapper = new ObjectMapper();
 
-    private static String extractJsonId(String body) {
-        // naive parse for \"id\":\"...\" or \"id\":123
+    @Post
+    public HttpResponse call(JsonNode req) {
         try {
-            int idx = body.indexOf("\"id\"");
-            if (idx >= 0) {
-                int colon = body.indexOf(':', idx);
-                if (colon > 0) {
-                    int start = colon + 1;
-                    // skip whitespace
-                    while (start < body.length() && Character.isWhitespace(body.charAt(start))) start++;
-                    if (start < body.length() && body.charAt(start) == '"') {
-                        int end = body.indexOf('"', start + 1);
-                        if (end > start) return '"' + body.substring(start + 1, end) + '"';
-                    } else {
-                        // number or other literal up to comma/brace
-                        int end = start;
-                        while (end < body.length() && ",}\n \t".indexOf(body.charAt(end)) == -1) end++;
-                        return body.substring(start, end);
-                    }
+            String id = req.has("id") ? req.get("id").toString() : "null";
+            String method = req.has("method") ? req.get("method").asText("") : "";
+            ObjectNode response = mapper.createObjectNode();
+            response.put("jsonrpc", "2.0");
+            if (!"call_tool".equals(method)) {
+                response.set("id", req.get("id"));
+                ObjectNode err = mapper.createObjectNode();
+                err.put("code", -32601);
+                err.put("message", "Method not found");
+                response.set("error", err);
+                return HttpResponses.ok(response.toString());
+            }
+
+            JsonNode params = req.path("params");
+            String name = params.path("name").asText("");
+            JsonNode args = params.path("arguments");
+            // arguments may come as JSON string; parse if so
+            if (args.isTextual()) {
+                try { args = mapper.readTree(args.asText()); } catch (Exception ignored) {}
+            }
+
+            ObjectNode result;
+            switch (name) {
+                case "fetch_logs" -> result = handleFetchLogs(args);
+                case "query_metrics" -> result = handleQueryMetrics(args);
+                default -> {
+                    result = mapper.createObjectNode();
+                    result.put("error", "Unknown tool: " + name);
                 }
             }
-        } catch (Exception ignored) {}
-        return "null";
+
+            response.set("id", req.get("id"));
+            response.set("result", result);
+            return HttpResponses.ok(response.toString());
+        } catch (Exception e) {
+            // Return JSON-RPC error object
+            String resp = String.format("{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32603,\"message\":\"Internal error: %s\"}}",
+                    escape(e.getMessage()));
+            return HttpResponses.ok(resp);
+        }
+    }
+
+    private ObjectNode handleFetchLogs(JsonNode args) {
+        String service = args.path("service").asText("");
+        int lines = args.path("lines").isInt() ? args.get("lines").asInt() : 200;
+        String range = args.path("range").asText(null);
+
+        String fileName = String.format("logs/%s.log", service);
+        String logs = readResourceText(fileName);
+        if (logs == null) {
+            logs = String.format("No log file found for service: %s", service);
+        }
+        String[] allLines = logs.split("\n");
+        int startIdx = Math.max(0, allLines.length - lines);
+        int actual = Math.min(lines, allLines.length);
+        StringBuilder tail = new StringBuilder();
+        for (int i = startIdx; i < allLines.length; i++) tail.append(allLines[i]).append('\n');
+
+        ObjectNode result = mapper.createObjectNode();
+        result.put("logs", tail.toString());
+        result.put("source", "classpath");
+        result.put("linesReturned", actual);
+        if (range != null) result.put("range", range);
+        result.put("service", service);
+        return result;
+    }
+
+    private ObjectNode handleQueryMetrics(JsonNode args) {
+        String expr = args.path("expr").asText("");
+        String range = args.path("range").asText("");
+        String file = determineMetricsFile(expr);
+        String raw = readResourceText(file);
+        if (raw == null) raw = String.format("No metrics file found for query: %s", expr);
+
+        ObjectNode result = mapper.createObjectNode();
+        result.put("raw", raw);
+        result.put("source", "classpath");
+        result.put("expr", expr);
+        result.put("range", range);
+        return result;
+    }
+
+    private static String determineMetricsFile(String expr) {
+        if (expr.contains("error") || expr.contains("fail")) {
+            return "metrics/payment-service-errors.json";
+        } else if (expr.contains("latency") || expr.contains("response_time")) {
+            return "metrics/payment-service-latency.json";
+        } else if (expr.contains("cpu") || expr.contains("memory") || expr.contains("resource")) {
+            return "metrics/user-service-resources.json";
+        } else if (expr.contains("throughput") || expr.contains("rate")) {
+            return "metrics/order-service-throughput.json";
+        } else {
+            return "metrics/payment-service-errors.json";
+        }
+    }
+
+    private static String readResourceText(String path) {
+        try {
+            InputStream in = McpMockEndpoint.class.getClassLoader().getResourceAsStream(path);
+            if (in == null) return null;
+            byte[] bytes = in.readAllBytes();
+            return new String(bytes, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String escape(String s) {
+        if (s == null) return "";
+        return s.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 }
-

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -82,5 +82,6 @@ logging.level {
   root = INFO
 }
 
-# Optional MCP HTTP JSON-RPC bridge (used by TriageAgent.mcpCall)
-# mcp.http.url = "http://localhost:7400/jsonrpc"
+# MCP HTTP JSON-RPC bridge endpoint
+# Default points to in-app mock server at /mcp. Override with env var MCP_HTTP_URL or system property MCP_HTTP_URL.
+mcp.http.url = "http://localhost:9100/mcp"

--- a/src/test/java/com/example/sample/WorkflowRecoveryTest.java
+++ b/src/test/java/com/example/sample/WorkflowRecoveryTest.java
@@ -8,6 +8,7 @@ import com.example.sample.application.EvidenceAgent;
 import com.example.sample.application.TriageAgent;
 import com.example.sample.application.RemediationAgent;
 import com.example.sample.application.SummaryAgent;
+import com.example.sample.application.KnowledgeBaseAgent;
 import com.example.sample.application.TriageWorkflow;
 import org.junit.jupiter.api.Test;
 
@@ -20,6 +21,7 @@ public class WorkflowRecoveryTest extends TestKitSupport {
     private final TestModelProvider triageModel = new TestModelProvider();
     private final TestModelProvider remediationModel = new TestModelProvider();
     private final TestModelProvider summaryModel = new TestModelProvider();
+    private final TestModelProvider knowledgeModel = new TestModelProvider();
 
     @Override
     protected TestKit.Settings testKitSettings() {
@@ -28,7 +30,8 @@ public class WorkflowRecoveryTest extends TestKitSupport {
                 .withModelProvider(EvidenceAgent.class, evidenceModel)
                 .withModelProvider(TriageAgent.class, triageModel)
                 .withModelProvider(RemediationAgent.class, remediationModel)
-                .withModelProvider(SummaryAgent.class, summaryModel);
+                .withModelProvider(SummaryAgent.class, summaryModel)
+                .withModelProvider(KnowledgeBaseAgent.class, knowledgeModel);
     }
 
     @Test
@@ -41,6 +44,7 @@ public class WorkflowRecoveryTest extends TestKitSupport {
         triageModel.fixedResponse("ok");
         remediationModel.fixedResponse("ok");
         summaryModel.fixedResponse("ok");
+        knowledgeModel.fixedResponse("ok");
 
         // Start to initialize state (this will begin classification immediately)
         componentClient

--- a/src/test/java/com/example/sample/WorkflowTest.java
+++ b/src/test/java/com/example/sample/WorkflowTest.java
@@ -9,6 +9,7 @@ import com.example.sample.application.RemediationAgent;
 import com.example.sample.application.SummaryAgent;
 import com.example.sample.application.TriageAgent;
 import com.example.sample.application.EvidenceAgent;
+import com.example.sample.application.KnowledgeBaseAgent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -21,6 +22,7 @@ public class WorkflowTest extends TestKitSupport {
     private final TestModelProvider remediationModel = new TestModelProvider();
     private final TestModelProvider summaryModel = new TestModelProvider();
     private final TestModelProvider evidenceModel = new TestModelProvider();
+    private final TestModelProvider knowledgeModel = new TestModelProvider();
 
     @Override
     protected TestKit.Settings testKitSettings() {
@@ -29,7 +31,8 @@ public class WorkflowTest extends TestKitSupport {
                 .withModelProvider(TriageAgent.class, triageModel)
                 .withModelProvider(RemediationAgent.class, remediationModel)
                 .withModelProvider(SummaryAgent.class, summaryModel)
-                .withModelProvider(EvidenceAgent.class, evidenceModel);
+                .withModelProvider(EvidenceAgent.class, evidenceModel)
+                .withModelProvider(KnowledgeBaseAgent.class, knowledgeModel);
     }
 
     @BeforeEach
@@ -46,6 +49,7 @@ public class WorkflowTest extends TestKitSupport {
         triageModel.fixedResponse("Hypothesis: db pool exhaustion\nActions: 1) rollback 2) scale db");
         remediationModel.fixedResponse("Plan: 1) rollback 2) validate 3) communicate");
         summaryModel.fixedResponse("Incident: Checkout errors\nImpact: elevated 5xx\nNext update: 30m");
+        knowledgeModel.fixedResponse("Runbooks found: checkout.md, payments_incident_2023-09.md");
 
         var wfId = "wf-test-1";
         var incident = "Checkout 5xx spike after deploy";


### PR DESCRIPTION
 - KnowledgeBaseAgent: use search_knowledge_base via model tools (.tools(this)); added system prompt; imports.
  - RemediationAgent: prompt clarified to review KB results, not call tool directly.
  - EvidenceAgent: fetch_logs, query_metrics delegate to MCP (via McpClient) with local fallback; parsed result fields; enriched outputs.
  - MCP server: implement JSON-RPC POST /mcp with tools:
      - fetch_logs → reads resources/logs/<service>.log, returns tail with metadata.
      - query_metrics → reads resources/metrics/*.json, returns raw metrics with metadata.
      - Accepts JSON object body; supports stringified arguments.
  - Config: mcp.http.url = "http://localhost:9100/mcp" in application.conf; McpClient/TriageAgent.mcpCall resolve endpoint via property/env/config/default.
  - Tests: register KnowledgeBaseAgent model provider in workflow tests for deterministic runs.
  - Dev tooling: add VS Code REST Client files:
      - docs/mcp.http with MCP requests + mapping notes to Loki/ELK/Splunk/Prometheus/Datadog/CloudWatch.
      - docs/triage.http for triage workflow endpoints.
